### PR TITLE
Fix for #10 (bug preventing translation)

### DIFF
--- a/Translate.h
+++ b/Translate.h
@@ -66,11 +66,11 @@ bool stringReplace(std::string& str, const std::string& from, const std::string&
 
 using namespace nlohmann;
 
-void trnslt::GoogleTranslate(ChatMessage1* message) {
+void trnslt::GoogleTranslate(FGFxChatMessage* message) {
     CurlRequest req;
-    req.url = std::format("https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl={}&dt=t&dt=bd&dj=1&q={}", cvarManager->getCvar("trnslt_language_to").getStringValue(), urlEncode(wToString(message->Message)));
+    req.url = std::format("https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl={}&dt=t&dt=bd&dj=1&q={}", cvarManager->getCvar("trnslt_language_to").getStringValue(), urlEncode(message->Message.ToString()));
 
-    std::string PlayerName = wToString(message->PlayerName);
+    std::string PlayerName = message->PlayerName.ToString();
     
     uint8_t Chat = message->ChatChannel;
     uint8_t TeamNum = 0;
@@ -83,12 +83,8 @@ void trnslt::GoogleTranslate(ChatMessage1* message) {
     {
         GameTime = server.GetSecondsRemaining();
     }
-
-    TeamWrapper team = TeamWrapper(reinterpret_cast<uintptr_t>(message->Team));
-
-    if (!team.IsNull()) {
-		TeamNum = team.GetTeamNum();
-    }
+    
+    TeamNum = message->Team;
 
     HttpWrapper::SendCurlRequest(req, [this, Chat, PlayerName, TeamNum, GameTime](int code, std::string result) {
         try {

--- a/logging.h
+++ b/logging.h
@@ -54,6 +54,7 @@ struct FormatWstring
 template <typename... Args>
 void LOG(std::string_view format_str, Args&&... args)
 {
+	_globalCvarManager->log(std::vformat(format_str, std::make_format_args(args...)));
 }
 
 template <typename... Args>

--- a/trnslt.cpp
+++ b/trnslt.cpp
@@ -41,7 +41,6 @@ void trnslt::onLoad() {
 
     }, "set transltate to language", PERMISSION_ALL);
 
-    this->HookChat();
     this->HookGameStart();
     this->AlterMsg();
 }
@@ -58,30 +57,6 @@ void trnslt::onUnload() {
     this->ReleaseHooks();
 }
 
-void trnslt::HookChat() {
-    // https://github.com/JulienML/BetterChat/blob/fd0650ae30c12c11c70302045cfd9d4b6e181759/BetterChat.cpp#L509
-    gameWrapper->HookEventWithCaller<ActorWrapper>("Function TAGame.HUDBase_TA.OnChatMessage", [this](ActorWrapper Caller, void* params, ...) {
-        if (params) {
-            ChatMessage1* message = (ChatMessage1*)params;
-            if (message->PlayerName == nullptr) return;
-            if (message->PlayerName == gameWrapper->GetPlayerName().ToWideString() && !cvarManager->getCvar("trnslt_translate_own").getBoolValue()) { return; }
-
-            if (message->ChatChannel == 0 && !cvarManager->getCvar("trnslt_translate_0").getBoolValue()) { return; }
-            if (message->ChatChannel == 1 && !cvarManager->getCvar("trnslt_translate_1").getBoolValue()) { return; }
-            if (message->ChatChannel == 2 && !cvarManager->getCvar("trnslt_translate_2").getBoolValue()) { return; }
-
-            if (message->Message == nullptr) return;
-            if (message->bPreset) return;
-
-			if (cvarManager->getCvar("trnslt_remove_message").getBoolValue()) {
-				this->CancelQueue.push_back({ wToString(message->Message), "", message->ChatChannel, wToString(message->PlayerName) });
-			}
-
-            LogTranslation(message);
-        }
-    });
-}
-
 // https://github.com/JulienML/BetterChat/blob/fd0650ae30c12c11c70302045cfd9d4b6e181759/BetterChat.cpp#L495
 void trnslt::AlterMsg () {
     gameWrapper->HookEventWithCaller<ActorWrapper>("Function TAGame.GFxData_Chat_TA.OnChatMessage", [this](ActorWrapper Caller, void* params, ...) {
@@ -89,6 +64,28 @@ void trnslt::AlterMsg () {
 
         if (!message)
             return;
+
+        // Ignore system messages
+        if (message->Team == -1) { return; }
+
+        // Ignore non-regular messages, such as from plugins (including ours)
+        if (message->MessageType != 0) { return; }
+        
+        // Ignore bakkesmod messages
+        //if (message->PlayerName.ToString() == "BAKKESMOD") { return; }
+
+        if (message->PlayerName.ToString() == gameWrapper->GetPlayerName().ToString() && !cvarManager->getCvar("trnslt_translate_own").getBoolValue()) { return; }
+
+        if (message->ChatChannel == 0 && !cvarManager->getCvar("trnslt_translate_0").getBoolValue()) { return; }
+        if (message->ChatChannel == 1 && !cvarManager->getCvar("trnslt_translate_1").getBoolValue()) { return; }
+        if (message->ChatChannel == 2 && !cvarManager->getCvar("trnslt_translate_2").getBoolValue()) { return; }
+
+        if (cvarManager->getCvar("trnslt_remove_message").getBoolValue()) {
+            this->CancelQueue.push_back({ message->Message.ToString(), "", message->ChatChannel, message->PlayerName.ToString() });
+        }
+
+        LogTranslation(message);
+        LOG("Translated message from user: {}", message->PlayerName.ToString());
 
         if (cvarManager->getCvar("trnslt_remove_message").getBoolValue()) {
             // check for message queue todo
@@ -291,7 +288,7 @@ void trnslt::RegisterCvars()
     cvarManager->registerCvar("trnslt_language_to", "en", "language to translate to", true, false, 0, false, 0, true);
 }
 
-void trnslt::LogTranslation(ChatMessage1* message) {
+void trnslt::LogTranslation(FGFxChatMessage* message) {
     switch (cvarManager->getCvar("trnslt_translate_api").getIntValue()) {
     case 0:
         GoogleTranslate(message);

--- a/trnslt.h
+++ b/trnslt.h
@@ -13,28 +13,6 @@ constexpr auto plugin_version = stringify(VERSION_MAJOR) "." stringify(VERSION_M
 
 extern std::string toLower(std::string str);
 
-struct ChatMessage1
-{
-	void* PRI;
-	void* Team;
-	wchar_t* PlayerName;
-	uint8_t PlayerNamePadding[0x8];
-	wchar_t* Message;
-	uint8_t MessagePadding[0x8];
-	uint8_t ChatChannel;
-	unsigned long bPreset : 1;
-};
-
-struct ChatMessage2 {
-	int32_t Team;
-	class FString PlayerName;
-	class FString Message;
-	uint8_t ChatChannel;
-	bool bLocalPlayer : 1;
-	unsigned char IDPadding[0x48];
-	uint8_t MessageType;
-};
-
 struct LogMessage {
 	std::string OriginalMessage;
 	std::string TranslatedMessage;

--- a/trnslt.h
+++ b/trnslt.h
@@ -60,15 +60,14 @@ class trnslt: public BakkesMod::Plugin::BakkesModPlugin, public SettingsWindowBa
 	void onUnload() override;
 
 public:
-	void LogTranslation(ChatMessage1* message);
+	void LogTranslation(FGFxChatMessage* message);
 
 	void HookGameStart();
-	void HookChat();
 	void ReleaseHooks();
 
 	void RenderSettings() override;
 
-	void GoogleTranslate(ChatMessage1* message);
+	void GoogleTranslate(FGFxChatMessage* message);
 	void AlterMsg();
 
 	void RegisterCvars();

--- a/utils.h
+++ b/utils.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <Windows.h>
 
 // hippity hoppity i copyti this from https://github.com/JulienML/BetterChat/commit/dedb44e8e543eb4b40e404257b4ef123404617f1?diff=split#diff-c2a4ceabc49cd85b048435a7850490d7fab95a64ffc33a813b02b6eebf8b14b4
 // gracie mille
@@ -56,11 +57,13 @@ public:
         if (!IsValid())
         {
             std::wstring wideStr(ArrayData);
-            std::string str(wideStr.begin(), wideStr.end());
+			int size_needed = WideCharToMultiByte(CP_UTF8, 0, wideStr.c_str(), (int)wideStr.length(), nullptr, 0, nullptr, nullptr);
+			std::string str(size_needed, 0);
+			WideCharToMultiByte(CP_UTF8, 0, wideStr.c_str(), (int)wideStr.length(), &str[0], size_needed, nullptr, nullptr);
             return str;
         }
 
-        return std::string();
+		return std::string("null");
     }
 
     bool IsValid() const

--- a/utils.h
+++ b/utils.h
@@ -10,95 +10,86 @@
 struct FString
 {
 public:
-    using ElementType = const wchar_t;
-    using ElementPointer = ElementType*;
+	using ElementType = const wchar_t;
+	using ElementPointer = ElementType*;
 
 private:
-    ElementPointer ArrayData;
-    int32_t ArrayCount;
-    int32_t ArrayMax;
+	ElementPointer ArrayData;
+	int32_t ArrayCount;
+	int32_t ArrayMax;
 
 public:
-    FString()
-    {
-        ArrayData = nullptr;
-        ArrayCount = 0;
-        ArrayMax = 0;
-    }
+	FString()
+	{
+		ArrayData = nullptr;
+		ArrayCount = 0;
+		ArrayMax = 0;
+	}
 
-    FString(ElementPointer other)
-    {
-        ArrayData = nullptr;
-        ArrayCount = 0;
-        ArrayMax = 0;
+	FString(ElementPointer other)
+	{
+		ArrayData = nullptr;
+		ArrayCount = 0;
+		ArrayMax = 0;
 
-        ArrayMax = ArrayCount = *other ? (wcslen(other) + 1) : 0;
+		ArrayMax = ArrayCount = *other ? (wcslen(other) + 1) : 0;
 
-        if (ArrayCount > 0)
-        {
-            ArrayData = other;
-        }
-    }
+		if (ArrayCount > 0)
+		{
+			ArrayData = other;
+		}
+	}
 
-    ~FString() {}
+	~FString() {}
 
 public:
-	std::wstring ToWideString() const
+	std::string ToString() const
 	{
 		if (!IsValid())
 		{
-			return std::wstring(ArrayData);
-		}
-		return std::wstring();
-	}
-
-    std::string ToString() const
-    {
-        if (!IsValid())
-        {
-            std::wstring wideStr(ArrayData);
+			std::wstring wideStr(ArrayData);
 			int size_needed = WideCharToMultiByte(CP_UTF8, 0, wideStr.c_str(), (int)wideStr.length(), nullptr, 0, nullptr, nullptr);
 			std::string str(size_needed, 0);
 			WideCharToMultiByte(CP_UTF8, 0, wideStr.c_str(), (int)wideStr.length(), &str[0], size_needed, nullptr, nullptr);
-            return str;
-        }
+			return str;
+		}
 
 		return std::string("null");
-    }
+	}
 
-    bool IsValid() const
-    {
-        return !ArrayData;
-    }
+	bool IsValid() const
+	{
+		return !ArrayData;
+	}
 
-    FString operator=(ElementPointer other)
-    {
-        if (ArrayData != other)
-        {
-            ArrayMax = ArrayCount = *other ? (wcslen(other) + 1) : 0;
+	FString operator=(ElementPointer other)
+	{
+		if (ArrayData != other)
+		{
+			ArrayMax = ArrayCount = *other ? (wcslen(other) + 1) : 0;
 
-            if (ArrayCount > 0)
-            {
-                ArrayData = other;
-            }
-        }
+			if (ArrayCount > 0)
+			{
+				ArrayData = other;
+			}
+		}
 
-        return *this;
-    }
+		return *this;
+	}
 
-    bool operator==(const FString& other)
-    {
-        return (!wcscmp(ArrayData, other.ArrayData));
-    }
+	bool operator==(const FString& other)
+	{
+		return (!wcscmp(ArrayData, other.ArrayData));
+	}
 };
 
 FString FS(const std::string& s) {
-    wchar_t* p = new wchar_t[s.size() + 1];
-    for (std::string::size_type i = 0; i < s.size(); ++i)
-        p[i] = s[i];
+	wchar_t* p = new wchar_t[s.size() + 1];
+	for (std::string::size_type i = 0; i < s.size(); ++i)
+		p[i] = s[i];
 
-    p[s.size()] = '\0';
-    return FString(p);
+	p[s.size()] = '\0';
+	return FString(p);
 }
 
 struct FSceNpOnlineId

--- a/utils.h
+++ b/utils.h
@@ -123,11 +123,11 @@ struct FUniqueNetId
 };
 struct FGFxChatMessage {
     int32_t Team;
-    class FString PlayerName;
-    class FString Message;
+	struct FString PlayerName;
+	struct FString Message;
     uint8_t ChatChannel;
     bool bLocalPlayer : 1;
     struct FUniqueNetId SenderID;
     uint8_t MessageType;
-    class FString TimeStamp;
+	struct FString TimeStamp;
 };

--- a/version.h
+++ b/version.h
@@ -2,7 +2,7 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
 #define VERSION_PATCH 3
-#define VERSION_BUILD 325
+#define VERSION_BUILD 382
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a

--- a/version.h
+++ b/version.h
@@ -2,7 +2,7 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
 #define VERSION_PATCH 3
-#define VERSION_BUILD 382
+#define VERSION_BUILD 386
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a


### PR DESCRIPTION
Fixes #10 by hooking into `TAGame.GFxData_Chat_TA.OnChatMessage` alone and moving all logic to that handler.

From what I observed, the events work as follows:
* For Quick Chat: First a `TAGame.HUDBase_TA.OnChatMessage` is sent containing the Quick Chat message ID, then a `TAGame.GFxData_Chat_TA.OnChatMessage` with the message text itself.
* For all other chat: Only a `TAGame.GFxData_Chat_TA.OnChatMessage` containing the message text

This is my first time using this plugin or working with BakkesMod, so I'm not sure if the event behavior just changed recently or has been like that for a while.

I have tested this on private matches, matchmaking games and freeplay, but have not tested with party chat.
